### PR TITLE
fix: remove id from URL when accordion closes

### DIFF
--- a/src/components/InnerAccordion/InnerAccordion.jsx
+++ b/src/components/InnerAccordion/InnerAccordion.jsx
@@ -9,7 +9,8 @@ export default function InnerAccordion({ title, id, children, expanded, expandTo
     e.preventDefault();
     e.stopPropagation();
     expandToggle(id);
-    window.history.replaceState({}, null, `#${id}`);
+    const accordionId = expanded ? '/' : `#${id}`;
+    window.history.replaceState({}, null, accordionId);
   };
 
   return (

--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -23,15 +23,17 @@ function Section({ title, id, children, Icon, expandToggle, expandedId }) {
   }, [expandedId]);
 
   const toggle = () => {
-    const accordionId = children[0].props.id;
+    let accordionId = '/';
+
     if (isOpen) {
       expandToggle(null);
       setIsOpen(false);
     } else {
-      expandToggle(accordionId);
+      accordionId = `#${children[0].props.id}`;
+      expandToggle(children[0].props.id);
       setIsOpen(true);
-      window.history.replaceState({}, null, `#${accordionId}`);
     }
+    window.history.replaceState({}, null, accordionId);
   };
 
   return (


### PR DESCRIPTION
**To Reproduce** Steps to reproduce the behavior:

1. Go to the site
2. Open one of the accordion or section
3. close it 

**What happens:**
- The URL keeeps the last opened section 

**Expected behavior** A clear and concise description of what you expected to happen.
- The URL should NOT have any ID as all accordions are closed


NOTE: THis need to be solved twice. When you CLOSE a section and when you CLOSE an individual sub section! Both have code that should be updated