### PR TITLE
fix:Sections closes when I click on a link

### DIFF
--- a/src/components/Card/Card.jsx
+++ b/src/components/Card/Card.jsx
@@ -9,6 +9,7 @@ function Card({ title, size = 'large', imageSrc, url }) {
       target="_blank"
       rel="noopener noreferrer"
       className={clsx(styles.container, styles[`container__${size}`])}
+      onClick={(e) => e.stopPropagation()}
     >
       <img src={imageSrc} alt={title} />
       {title}


### PR DESCRIPTION
Steps:
- open the site
- open a section
- Click on one of the card
- A new tab opens with the link
- go back to the site

What happens
- THe section that was previously open is now closed

What should happen:
- [x] Clicking an individual link should NOT close the section