### PR TITLE
Pr 103/general resources default open

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,10 +20,10 @@ export default function Home() {
   };
 
   useEffect(() => {
-    const DEFAULT_OPEN_SECTION_ID = 'general-learning-resources';
+    const DEFAULT_ACCORDION_ID = 'general-learning-resources';
     const { asPath } = router;
     let id = asPath.split('#')[1];
-    id = id ? id : DEFAULT_OPEN_SECTION_ID;
+    id = id ? id : DEFAULT_ACCORDION_ID;
     router.replace(asPath);
     expandPanel(id || null);
   }, []);


### PR DESCRIPTION
When I first access the site, I would like the first entry "general Learning resources" to be opened to help people to understand that each section includes more entries.

AC:
- [x] When I load the app with no ID specified in the URL, The general learning resources should open (we can append it to the URL if necessary).
- [x] If I just close all sections (and therefore have no ID left), the "general learning resources" should NOT open