### PR TITLE
fix: when accordion is closed, tab takes focus to the next accordion

### DIFF
--- a/src/components/InnerAccordion/InnerAccordion.jsx
+++ b/src/components/InnerAccordion/InnerAccordion.jsx
@@ -34,6 +34,7 @@ export default function InnerAccordion({ title, id, children, expanded, expandTo
         id={`${id}-sect`}
         aria-labelledby={`${id}-accordionid`}
         className={clsx(styles.panel, { [styles.active]: expanded })}
+        hidden={!expanded}
       >
         {children}
       </div>


### PR DESCRIPTION
Steps:
- Click tabs to access the sections (DO NOT USE THE MOUSE IN THIS ISSUE)
- reach the first sub-section "General Learning Resources"
- Click tab

What should have happened:
- The next focused item should be the next sub section "3rd Party Learning Journeys" as the first was closed

What happened
- The element that is actually focused is the first entry of the first section even if it is actually HIDDEN!

NOTE: there may be some issue with the current aria roles assigned. Check that again and try to isolate the issue