### PR TITLE
Fix: added custom hook to detect scroll direction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4491,11 +4491,14 @@
       }
     },
     "node_modules/@storybook/addon-controls/node_modules/watchpack/chokidar2": {
-      "version": "0.0.1",
+      "version": "2.0.0",
       "dev": true,
       "optional": true,
       "dependencies": {
         "chokidar": "^2.1.8"
+      },
+      "engines": {
+        "node": "<8.10.0"
       }
     },
     "node_modules/@storybook/addon-controls/node_modules/webpack": {

--- a/src/components/NavbarItemList/NavbarItemList.jsx
+++ b/src/components/NavbarItemList/NavbarItemList.jsx
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 import { useStateValue } from '@/context/StateProvider';
 import { SET_ACTIVE_SECTION, SET_MORE_ENTITY_SHADOW, SET_PROGRESS } from '@/context/types';
 import useIntersection from '@/helpers/useIntersection';
+import useScrollDirection from '@/helpers/useScrollDirection';
 
 export default function NavbarItemList({ id, navbar, navWidth, children }) {
   const ref = useRef();
   const isVisible = useIntersection(ref, navbar);
   const [{ visible, activeSection }, dispatch] = useStateValue();
+  const { scrolledUp } = useScrollDirection();
 
   useEffect(() => {
     const updateProgress = (section_id, addedValue) => {
@@ -34,7 +36,7 @@ export default function NavbarItemList({ id, navbar, navWidth, children }) {
         }
       }
 
-      if (activeSection === 'learn' && !section_id) {
+      if (activeSection === 'learn' && !section_id && scrolledUp) {
         dispatch({ type: SET_PROGRESS, payload: 0 });
         dispatch({ type: SET_ACTIVE_SECTION, payload: null });
       }

--- a/src/helpers/useIntersection.js
+++ b/src/helpers/useIntersection.js
@@ -5,7 +5,7 @@ const useIntersection = (element, root = null) => {
 
   useEffect(() => {
     const section = element.current;
-    const navHeight = !root ? '-100px' : '0px';
+    const navHeight = !root ? '-100px' : '-30px';
     const rootElement = root?.current;
 
     const observer = new IntersectionObserver(

--- a/src/helpers/useScrollDirection.js
+++ b/src/helpers/useScrollDirection.js
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export default function useScrollDirection() {
+  const [y, setY] = useState(0);
+  const [scrolledUp, setScrolledUP] = useState(false);
+  const [scrolledDown, setScrolledDown] = useState(false);
+
+  const handleNavigation = useCallback(
+    (e) => {
+      const window = e.currentTarget;
+      if (y > window.scrollY) {
+        setScrolledUP(true);
+        setScrolledDown(false);
+      } else if (y < window.scrollY) {
+        setScrolledDown(true);
+        setScrolledUP(false);
+      }
+      setY(window.scrollY);
+    },
+    [y]
+  );
+
+  useEffect(() => {
+    setY(window.scrollY);
+    window.addEventListener('scroll', handleNavigation);
+
+    return () => {
+      window.removeEventListener('scroll', handleNavigation);
+    };
+  }, [handleNavigation]);
+
+  return {
+    scrolledDown,
+    scrolledUp,
+  };
+}


### PR DESCRIPTION
Making the observer track the section won't work as it should, so for this situation I just created a custom hook that will help check scroll direction, now everything works as expected.