### PR TITLE
Bug:Search event fix

### DIFF
--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { searchItem } from './fuse';
 import filterMatchedResult from '@/helpers/filterMatchedResult';
 import SearchResult from './SearchResult';
+import { useFocusOut } from '@/helpers/useFocusOut';
 
 export default function Search() {
   const inputRef = useRef();
@@ -18,11 +19,20 @@ export default function Search() {
   const [showBlockchain, setShowBlockchain] = useState(false);
   const [showSections, setShowSections] = useState(false);
 
+  const removeScrollPadding = (target) => {
+    if (target.style) {
+      target.style.scrollPaddingTop = 'unset';
+    }
+  };
+  const addScrollPadding = (target) => {
+    if (target.style) {
+      target.style.scrollPaddingTop = '12rem';
+    }
+  };
+
   const handleSearch = (e) => {
     // Remove the scroll padding top to prevent scroll on key press
-    if (e.nativeEvent.path[6].style) {
-      e.nativeEvent.path[6].style.scrollPaddingTop = 'unset';
-    }
+    removeScrollPadding(e.nativeEvent?.path[6]);
 
     const value = e.target.value;
     setSearch(value);
@@ -48,9 +58,7 @@ export default function Search() {
 
       // return the scroll padding top to its normal value
       setTimeout(() => {
-        if (e.nativeEvent.path[6].style) {
-          e.nativeEvent.path[6].style.scrollPaddingTop = '12rem';
-        }
+        addScrollPadding(e.nativeEvent?.path[6]);
       });
     }
   };
@@ -58,12 +66,15 @@ export default function Search() {
     setSearch('');
   };
 
+  useFocusOut(inputRef, clear);
+
   useEffect(() => {
     window.addEventListener('keydown', (e) => {
       const f = e.keyCode === 70;
       const ctrl = e.ctrlKey;
       const f3 = e.keyCode === 114;
       const esc = e.keyCode === 27;
+      const tab = e.keyCode === 9;
 
       if (f3 || (ctrl && f)) {
         e.preventDefault();
@@ -74,6 +85,12 @@ export default function Search() {
         e.preventDefault();
         inputRef.current.blur();
         clear();
+      }
+      if (tab && e.path[6]) {
+        removeScrollPadding(e.path[6]);
+        setTimeout(() => {
+          addScrollPadding(e.path[6]);
+        }, 1000);
       }
     });
 

--- a/src/components/Search/SearchResult/SearchResult.jsx
+++ b/src/components/Search/SearchResult/SearchResult.jsx
@@ -19,8 +19,7 @@ export default function SearchResult({ hasBlockchains, hasResources, hasSections
     [focus, data]
   );
 
-  useOutsideClick(resultRef, () => clear());
-
+  useOutsideClick(resultRef, clear);
   return (
     <div ref={resultRef} className={styles.results}>
       <div className={styles.content}>

--- a/src/helpers/useFocusOut.js
+++ b/src/helpers/useFocusOut.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+export const useFocusOut = (containerRef, clickHandler) => {
+  useEffect(() => {
+    const handleFocusOut = (event) => {
+      const tab = event.keyCode === 9;
+      const searchOptions = event.target.className && event.target.className.includes('Search');
+
+      if (tab && !searchOptions) {
+        clickHandler();
+      }
+    };
+
+    document.addEventListener('keyup', handleFocusOut);
+    return () => {
+      document.addEventListener('keyup', handleFocusOut);
+    };
+  }, [containerRef, clickHandler]);
+};

--- a/src/helpers/useOutsideClick.js
+++ b/src/helpers/useOutsideClick.js
@@ -5,8 +5,9 @@ export const useOutsideClick = (containerRef, clickHandler) => {
     const handleClickOutside = (event) => {
       const isInput = event.target.nodeName.toLowerCase() === 'input';
       const isSvg = event.target.nodeName.toLowerCase() === 'svg';
+
       if (containerRef.current && !containerRef.current.contains(event.target) && !isInput && !isSvg) {
-        clickHandler();
+        clickHandler(); //callback function
       }
     };
 


### PR DESCRIPTION
- [x] When you scroll down away from the navbar and the input field is on focus and you press `Tab button` it scrolls up when there is a search result.

**Fix**
Toggle the scroll-padding-top just like how it was done in the onChange event of the input field

- [x] Hide Results when there is no focus on it while using tab