### PR TITLE
Router bug on refresh

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -93,10 +93,12 @@ export default function Home() {
   useEffect(() => {
     const DEFAULT_ACCORDION_ID = getAllSubSections();
     let mounted = true;
+    let { asPath } = router;
+    asPath = asPath.split('/');
+    asPath = asPath.length > 0 ? asPath[1] : '/';
 
     if (!mounted) {
-      const { asPath } = router;
-      router.push(asPath || '/');
+      router.replace(asPath || '/');
     }
 
     let openedChapters = JSON.parse(localStorage.getItem('opened'));


### PR DESCRIPTION
When there is a path on the url(which can be achieved by scrolling through the page) , then you refresh the page it shows an error like the image below.
### in console
![Screenshot from 2022-08-01 15-54-21](https://user-images.githubusercontent.com/28502531/182185387-c5dde1d2-ae6f-427d-8728-676cac87a5c8.png)


### On the web page
![Screenshot from 2022-08-01 15-54-42](https://user-images.githubusercontent.com/28502531/182185394-bd830e72-01b5-4761-ade3-63d42d4f019a.png)
