### PR TITLE
chore: made all part of card clickable

### DIFF
--- a/src/components/WelcomeSectionCard/WelcomeSectionCard.jsx
+++ b/src/components/WelcomeSectionCard/WelcomeSectionCard.jsx
@@ -7,27 +7,29 @@ export default function WelcomeSectionCard({ title, totalItem, items, children }
   const linkText = title.toLowerCase();
 
   return (
-    <div className={styles.wrapper}>
-      <div className={styles.info}>
-        <div className={styles.title}>
-          <span className={styles.icon}>{children}</span>
-          {title}
-        </div>
-        <div className={styles.count}>{totalItem}</div>
-      </div>
-      <div className={styles.card}>
-        <a href={`/map#${linkText}`} className={styles.overlay}>
-          <span className={styles.link}>
-            <NewTabIcon />
-          </span>
-        </a>
-        {items.map(({ url, logo, title }) => (
-          <div key={url + title} className={styles.card_item}>
-            <img src={logo} alt={title + 'logo'} />
+    <a href={`/map#${linkText}`}>
+      <div className={styles.wrapper}>
+        <div className={styles.info}>
+          <div className={styles.title}>
+            <span className={styles.icon}>{children}</span>
+            {title}
           </div>
-        ))}
+          <div className={styles.count}>{totalItem}</div>
+        </div>
+        <div className={styles.card}>
+          <div className={styles.overlay}>
+            <span className={styles.link}>
+              <NewTabIcon />
+            </span>
+          </div>
+          {items.map(({ url, logo, title }) => (
+            <div key={url + title} className={styles.card_item}>
+              <img src={logo} alt={title + 'logo'} />
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+    </a>
   );
 }
 

--- a/src/components/WelcomeSectionCard/WelcomeSectionCard.module.scss
+++ b/src/components/WelcomeSectionCard/WelcomeSectionCard.module.scss
@@ -38,7 +38,11 @@ $card_height: 14rem;
       padding: 0.125rem 0.5rem;
       transform: translateY(-0.2rem);
       transition: all 0.2s ease-in-out;
-   } 
+   }
+
+   .title, .count {
+    cursor: pointer;
+   }
     margin-bottom: 0.75rem;
   }
   


### PR DESCRIPTION
As a visitor, I would like to be able to click the whole card to navigate to the map and not just its body

ac:
- [x] Show the pointer also when hovering on the Icon, title and number
- [x] Allow the user to click all parts of the card to navigate

![Screenshot 2022-08-24 at 11 40 51](https://user-images.githubusercontent.com/9040770/186399309-838ec1a2-4526-4d6d-896c-8b458353a2bc.png)



