### PR TITLE
Header responsive homepage

### DIFF
--- a/src/components/WelcomeBanner/WelcomeBanner.module.scss
+++ b/src/components/WelcomeBanner/WelcomeBanner.module.scss
@@ -15,7 +15,9 @@
 
 .content {
   flex: 1;
-  margin-left: 2rem;
+  @media (min-width: 760px) {
+    margin-left: 2rem;
+  }
 
   @media (min-width: 1024px) {
     flex: 0 40%;
@@ -28,7 +30,7 @@
 .heading_container {
   width: 100%;
   
-  @media (min-width: 768px) {
+  @media (min-width: 760px) {
     max-width: 27.25rem;
   }
 }


### PR DESCRIPTION
Change the current responsive behaviour of the header to actually keep the two column until on smaller screen. The header currently changes and provide a 100% to the text as soon as the screen shrinks.

- [x] Show two column (there is plenty of space between the two column to use) for screen that are greater or queal than the tablet endpoint (around 760ox it should be)
- [x] Sho two rows on screen below the tables breakpoint


![Screenshot 2022-08-24 at 15 03 17](https://user-images.githubusercontent.com/28502531/186442219-35138f5d-e755-44a2-84a3-a2678b50ead1.jpg)

![Screenshot 2022-08-24 at 15 18 15](https://user-images.githubusercontent.com/28502531/186442330-2f62278a-1787-4e5c-ae76-85dbb28ab24e.jpg)

