### PR TITLE
chore: responsive resource

### DIFF
--- a/src/components/WelcomeSectionCard/WelcomeSectionCard.module.scss
+++ b/src/components/WelcomeSectionCard/WelcomeSectionCard.module.scss
@@ -50,7 +50,7 @@ $card_height: 14rem;
   
   .card {
     width: 100%;
-    height: $card_height;
+    max-height: $card_height;
     overflow-y: auto;
     scrollbar-width: none;
     padding: 1.5rem 1.5rem;
@@ -95,10 +95,15 @@ $card_height: 14rem;
   }
 
     display: inline-grid;
-    grid-template-columns: repeat(4, 2rem);
+    grid-template-columns: repeat(7, 2rem);
     gap: 1rem;
     grid-auto-rows: 2rem;
     justify-content: center;
+
+    @media  (min-width: $tablet) {
+      height: 100%;
+      grid-template-columns: repeat(4, 2rem);
+    }
 
     .card_item {
       height: 2rem;
@@ -174,14 +179,8 @@ $card_height: 14rem;
       display: none;
     }
   }
-
-  @media (max-width: $laptop) {
-    &::after {
-      display: none;
-    }
-  }
  
-  @media (min-width: $laptop) and (max-width: $xl) {
+  @media (min-width: $laptop-md) and (max-width: $xl) {
     &::after {
       display: block;
     }

--- a/src/styles/Home.module.scss
+++ b/src/styles/Home.module.scss
@@ -42,9 +42,12 @@
   flex-direction: column;
   justify-content: center;
   gap: 2rem;
-  padding-inline: 1.5rem;
+  padding-inline: 1rem;
   overflow-x: hidden;
 
+  @media (min-width: $laptop) {
+    padding-inline: 1.5rem;
+  }
   @media (min-width: $xl) {
     padding-inline: 0.8rem;
   }

--- a/src/styles/_breakpoints.scss
+++ b/src/styles/_breakpoints.scss
@@ -3,6 +3,7 @@ $mobile-md: 480px;
 $mobile-lg: 540px;
 $tablet: 768px;
 $laptop: 1024px;
+$laptop-md: 1040px;
 $desktop: 1200px;
 $xl: 1276px;
 $xxl: 1376px;


### PR DESCRIPTION
AC:
- [x] On small screen (when there is just one column of the card), we should align the resources to take all the space available and not just been aligned in the middle.

<img width="495" alt="image" src="https://user-images.githubusercontent.com/9040770/188436475-c3bb2989-c7c4-46cf-9e92-48da695f098f.png">


![Blockchain-Ecosystem-Map (3)](https://user-images.githubusercontent.com/28502531/188446204-e665cfe1-714a-44ac-be84-c987f852c5c6.png)
