### PR TITLE
chore: gradient animation using pseudo

### DIFF
--- a/src/components/WelcomeBanner/WelcomeBanner.module.scss
+++ b/src/components/WelcomeBanner/WelcomeBanner.module.scss
@@ -64,14 +64,33 @@
   flex-direction: row;
   flex-wrap: nowrap;
   margin-bottom: 1rem;
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: $light-blue-gradient;
+    z-index: -1;
+    opacity: 0;
+    transition: opacity 0.5s linear;
+  }
 
   svg {
-    transition: all 0.1s ease-in-out;
+    transition: all 0.2s ease-in-out;
   }
   
   &:hover {
-    background: $light-blue-gradient;
     color: $white;
+
+    &::before {
+      opacity: 1;
+    }
   }
   transition: all 0.2s ease-in-out;
 }


### PR DESCRIPTION
The current animation on the CTA button on the homepage changes the color too quickly. All other changes (text color and others are completed at 0.2 seconds, but the background color changes instantaneously).

AC:
- [x] Change the Background color of the homepage CTA to also have a 0.2 second transition.

<img width="624" alt="image" src="https://user-images.githubusercontent.com/9040770/188434417-44611809-6af5-4845-bcf9-d68ac18d17a3.png">

## Fix

Used Pseudo to fix the transition speed since by default gradient can't transition.
