### PR TITLE
chore: ignore updates for everything related to jest

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,3 +23,6 @@ updates:
       # only get the _freshest_ of new packages to consider upgrading
       - dependency-name: "react-gtm-module"
       - dependency-name: "react-tooltip-lite"
+      - dependency-name: "jest"
+      - dependency-name: "jest-environment-jsdom"
+      - dependency-name: "jest-transform-yaml"


### PR DESCRIPTION
We have ignored any update for packages related to jest.